### PR TITLE
Updated schema to use [dbo] for tests

### DIFF
--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -11,7 +11,7 @@ def test_flat_file_to_sql():
         'password': os.environ['MSSQL_SA_PASSWORD']
     }
     sql_table_name = 'test_data1'
-    schema = 'my_test_schema'
+    schema = 'dbo'
     csv_file_path = 'tests/data1.csv'
     c = bcpy.FlatFile(qualifier='', path=csv_file_path)
     sql_table = bcpy.SqlTable(


### PR DESCRIPTION
Since the tests are designed to run in a docker container it makes sense to set it to use dbo as the schema, tests were failing on initial clone due to a non-existent schema.