### PR TITLE
Update the keyword argument lineterminator in data_objects.py

### DIFF
--- a/bcpy/data_objects.py
+++ b/bcpy/data_objects.py
@@ -317,7 +317,7 @@ class DataFrame(DataObject):
             sep=delimiter,
             quotechar=qualifier,
             quoting=csv.QUOTE_ALL,
-            line_terminator=newline,
+            lineterminator=newline,
             path_or_buf=csv_file_path)
         self._flat_file_object = FlatFile(
             delimiter=',',


### PR DESCRIPTION
fix error to_csv() got an unexpected keyword argument 'line_terminator' in data_objects.py